### PR TITLE
feat: add an environmental variable to disable `tmux rename-session`

### DIFF
--- a/shell/snippet/widget/zeno-ghq-cd
+++ b/shell/snippet/widget/zeno-ghq-cd
@@ -24,7 +24,7 @@ fi
 BUFFER="cd ${dir// /\\ }"
 zle accept-line
 
-if [[ -n $TMUX ]]; then
+if [[ -n $TMUX && -z $ZENO_DISABLE_TMUX_SESSION_RENAME ]]; then
   repository=${dir:t}
   session=${repository//./-}
   tmux rename-session "${session}"


### PR DESCRIPTION
Added an environmental variable `$ZENO_DISABLE_TMUX_SESSION_RENAME` to disable `tmux rename-session`.